### PR TITLE
docs(readme): fix info about configuration changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,20 +84,23 @@ Other commands: please see ```package.json``` for other commands.
 Below are just my experiences working in those tools. They can be inaccurate.   
 ### Lerna
 ✅ Supports both same and different versions of libraries (such as Angular, RxJs)   
-✅ 100% Native. No need to change configuration of applications (such as angular.json) to make it work  
+✅ Native - Use Angular CLI   
+❌ Configuration of applications required a change to `angular.json` to make it work. Switched to `ngx-build-plus` builders to support custom webpack config.  
 ❌ Slow development efficiency. Rebuild everytime you make changes to common packages such as UI   
 ❌ No dependency graph   
 
 ### Nx
 ❌ Not supports both same and different versions of libraries (such as Angular, RxJs). Only Monorepo.   
-❌ Not native. Needs to change configuration of applications (such as angular.json).   
-  Uses custom plugins instead of native angular/cli. Problems with adding new packages (such as ssr)   
+❌ Not native. Uses Nx CLI  
+❌ Configuration of applications required a change to `angular.json` to make it work. Switched to Nx Officially Supported Builders to support custom webpack config.   
+  Problems with adding new packages (such as ssr)    
 ✅ Very fast development efficiency   
-✅ Poweful dependency graph   
+✅ Powerful dependency graph   
 
 ### Turborepo
 ❌ Not supports both same and different versions of libraries (such as Angular, RxJs). Only Monorepo.   
-✅ Native. No need to change configuration of applications (such as angular.json).   
+✅ Native - Use Angular CLI  
+❌ Configuration of applications required a change to `angular.json` to make it work. Switched to `ngx-build-plus` builders to support custom webpack config.   
 ✅ Fast development efficiency   
 ✅ Dependency graph  
 


### PR DESCRIPTION
Hey :)

The information regarding the configuration changes required in the angular.json file appears to be incorrect.

From what I can see looking at the project, the `angular.json` file has required a change to the builder used to build and serve the angular app. 

Understandably, this is required to allow for additional webpack config to be passed to the Angular Devkit, which is required to allow the setup of the Module Federation Plugin.

However, in the README, it states that there were no changes required to `angular.json` for Lerna and Turborepo, despite changes having actually been made in those repos.

This PR aims to address that miscommunication.

This is a cool project!!